### PR TITLE
chore(mongodb): Implement intergration for MongoDB

### DIFF
--- a/docker-compose-mongo.yml
+++ b/docker-compose-mongo.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  mongo:
+    image: mongo:7.0
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+    networks:
+      - mongo-network
+
+volumes:
+  mongo-data:
+    driver: local
+
+networks:
+  mongo-network:
+    driver: bridge

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-mongodb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
@@ -58,6 +62,17 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mongodb</artifactId>
+			<version>1.19.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>20.0</version>
@@ -66,6 +81,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-sync</artifactId>
+			<version>4.10.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-core</artifactId>
+			<version>4.10.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -82,6 +107,11 @@
 			<artifactId>lombok</artifactId>
 			<version>1.18.26</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,6 @@
 			<version>20.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongodb-driver-sync</artifactId>
 			<version>4.10.2</version>

--- a/src/main/java/com/andrearozaki/urlshortener/entity/UrlEntity.java
+++ b/src/main/java/com/andrearozaki/urlshortener/entity/UrlEntity.java
@@ -2,20 +2,21 @@ package com.andrearozaki.urlshortener.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
 import java.time.LocalDateTime;
 
-@Entity
+@Document(collection = "url_mappings")
 @Data
 public class UrlEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
-    @Column(unique = true, nullable = false)
+    @Indexed(unique = true)
     private String shortUrl;
 
-    @Column(nullable = false)
     private String longUrl;
 
     private LocalDateTime creationDate;

--- a/src/main/java/com/andrearozaki/urlshortener/repository/UrlMappingRepository.java
+++ b/src/main/java/com/andrearozaki/urlshortener/repository/UrlMappingRepository.java
@@ -1,12 +1,12 @@
 package com.andrearozaki.urlshortener.repository;
 
 import com.andrearozaki.urlshortener.entity.UrlEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
-public interface UrlMappingRepository extends JpaRepository<UrlEntity, Long> {
+public interface UrlMappingRepository extends MongoRepository<UrlEntity, Long> {
         Optional<UrlEntity> findByShortUrl(String shortUrl);
 }

--- a/src/main/java/com/andrearozaki/urlshortener/util/UrlEncoder.java
+++ b/src/main/java/com/andrearozaki/urlshortener/util/UrlEncoder.java
@@ -1,10 +1,12 @@
 package com.andrearozaki.urlshortener.util;
 
 import com.google.common.hash.Hashing;
+import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 
+@Component
 public class UrlEncoder {
     public String encodeUrl(String url, LocalDateTime time) {
         return Hashing.murmur3_32()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=urlshortener
+spring.data.mongodb.host=localhost
+spring.data.mongodb.port=27017
+spring.data.mongodb.database=urlshorneter

--- a/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
+++ b/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
@@ -53,7 +53,6 @@ public class UrlMappingIntegrationTest {
         // Save the URL using the service
         urlService.createUrlMapping(firstUrlRequestDTO);
         urlService.createUrlMapping(secondUrlRequestDTO);
-
         List<UrlEntity> urls = mongoTemplate.findAll(UrlEntity.class);
 
         // Verify the results

--- a/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
+++ b/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.andrearozaki.urlshortener.intergration;
+
+import com.andrearozaki.urlshortener.dto.request.UrlRequestDTO;
+import com.andrearozaki.urlshortener.entity.UrlEntity;
+import com.andrearozaki.urlshortener.service.UrlService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+@Testcontainers
+public class UrlMappingIntegrationTest {
+
+    @Container
+    static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0").withExposedPorts(27017);
+
+    @DynamicPropertySource
+    static void containersProperties(DynamicPropertyRegistry registry) {
+        mongoDBContainer.start();
+        registry.add("spring.data.mongodb.host", mongoDBContainer::getHost);
+        registry.add("spring.data.mongodb.port", mongoDBContainer::getFirstMappedPort);
+    }
+
+    @Autowired
+    private UrlService urlService;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @AfterEach
+    public void cleanup() {
+        mongoTemplate.dropCollection(UrlEntity.class);
+    }
+
+    @Test
+    void testCreateMultipleUrls() {
+        UrlRequestDTO firstUrlRequestDTO = new UrlRequestDTO();
+        firstUrlRequestDTO.setLongUrl("https://longurl.com");
+        firstUrlRequestDTO.setCreationDate(LocalDateTime.now());
+
+        UrlRequestDTO secondUrlRequestDTO = new UrlRequestDTO();
+        secondUrlRequestDTO.setLongUrl("https://google.com");
+        secondUrlRequestDTO.setCreationDate(LocalDateTime.now());
+
+        // Save the URL using the service
+        urlService.createUrlMapping(firstUrlRequestDTO);
+        urlService.createUrlMapping(secondUrlRequestDTO);
+
+        List<UrlEntity> urls = mongoTemplate.findAll(UrlEntity.class);
+
+        // Verify the results
+        Assertions.assertEquals(2, urls.size());
+        Assertions.assertEquals("https://longurl.com", urls.get(0).getLongUrl());
+        Assertions.assertNotNull(urls.get(0).getShortUrl());
+        Assertions.assertEquals("https://google.com", urls.get(1).getLongUrl());
+        Assertions.assertNotNull(urls.get(1).getShortUrl());
+    }
+
+}


### PR DESCRIPTION
## Description

This pr adds intergration with MongoDB database. Using MongoDB for a URL shortening application can be quite advantageous due to several key characteristics of the database. Here’s a breakdown of why MongoDB might be a good fit for this use case due its flebible schema and scaling cababilities. This does the following modifications:

- Adds a MongoDB document called `url_mappings` via the springframework mongo library.
- Creates a MongoDB index on the `shortUrl` field in order to speed up  lookups
- Switches from `JPA` to `MongoDB` repository
- Creates a `docker-compose-mongo.yml ` file which can assist in building mongo db locally in  a docker container
- Modifies the `application.properties` file in order specify the mongodb connection data
- Adds intergration tests via test containers which assist in verifying the intergration between `service`, `repository` and `mongodb` layer
