### PR TITLE
feat(api): Add Caffeine for in memory caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-testcontainers</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -107,6 +111,11 @@
 			<groupId>org.testcontainers</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>3.1.8</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/andrearozaki/urlshortener/UrlshortenerApplication.java
+++ b/src/main/java/com/andrearozaki/urlshortener/UrlshortenerApplication.java
@@ -2,8 +2,10 @@ package com.andrearozaki.urlshortener;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class UrlshortenerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/andrearozaki/urlshortener/config/CacheConfig.java
+++ b/src/main/java/com/andrearozaki/urlshortener/config/CacheConfig.java
@@ -1,0 +1,25 @@
+package com.andrearozaki.urlshortener.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("urlcache");
+        cacheManager.setCaffeine(Caffeine.newBuilder()
+                .expireAfterWrite(6, TimeUnit.HOURS)
+                .maximumSize(1000)
+                .recordStats());
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/andrearozaki/urlshortener/service/UrlService.java
+++ b/src/main/java/com/andrearozaki/urlshortener/service/UrlService.java
@@ -10,6 +10,7 @@ import com.andrearozaki.urlshortener.util.UrlEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -48,6 +49,7 @@ public class UrlService {
         }
     }
 
+    @Cacheable(value = "urlcache", key="{#shortUrl}")
     public UrlResponseDTO getLongUrl(String shortUrl) {
         logger.info("Retrieving long URL for short URL: {}", shortUrl);
         Optional<UrlEntity> optionalUrl = repository.findByShortUrl(shortUrl);

--- a/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
+++ b/src/test/java/com/andrearozaki/urlshortener/intergration/UrlMappingIntegrationTest.java
@@ -1,11 +1,16 @@
 package com.andrearozaki.urlshortener.intergration;
 
 import com.andrearozaki.urlshortener.dto.request.UrlRequestDTO;
+import com.andrearozaki.urlshortener.dto.response.UrlResponseDTO;
 import com.andrearozaki.urlshortener.entity.UrlEntity;
+import com.andrearozaki.urlshortener.repository.UrlMappingRepository;
 import com.andrearozaki.urlshortener.service.UrlService;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -15,8 +20,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 @SpringBootTest
 @Testcontainers
+@EnableCaching
 public class UrlMappingIntegrationTest {
 
     @Container
@@ -35,13 +46,19 @@ public class UrlMappingIntegrationTest {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private CacheManager cacheManager;
+
+    @SpyBean
+    private UrlMappingRepository repository;
+
     @AfterEach
     public void cleanup() {
         mongoTemplate.dropCollection(UrlEntity.class);
     }
 
     @Test
-    void testCreateMultipleUrls() {
+    public void testCreateMultipleUrls() {
         UrlRequestDTO firstUrlRequestDTO = new UrlRequestDTO();
         firstUrlRequestDTO.setLongUrl("https://longurl.com");
         firstUrlRequestDTO.setCreationDate(LocalDateTime.now());
@@ -56,11 +73,35 @@ public class UrlMappingIntegrationTest {
         List<UrlEntity> urls = mongoTemplate.findAll(UrlEntity.class);
 
         // Verify the results
-        Assertions.assertEquals(2, urls.size());
-        Assertions.assertEquals("https://longurl.com", urls.get(0).getLongUrl());
-        Assertions.assertNotNull(urls.get(0).getShortUrl());
-        Assertions.assertEquals("https://google.com", urls.get(1).getLongUrl());
-        Assertions.assertNotNull(urls.get(1).getShortUrl());
+        assertEquals(2, urls.size());
+        assertEquals("https://longurl.com", urls.get(0).getLongUrl());
+        assertNotNull(urls.get(0).getShortUrl());
+        assertEquals("https://google.com", urls.get(1).getLongUrl());
+        assertNotNull(urls.get(1).getShortUrl());
+    }
+
+    @Test
+    void testGetLongUrlWithCaching() {
+        // Step 1: Create a URL mapping
+        UrlRequestDTO urlRequestDTO = new UrlRequestDTO();
+        urlRequestDTO.setLongUrl("https://example.com");
+        urlRequestDTO.setCreationDate(LocalDateTime.now());
+
+        UrlResponseDTO createdUrl = urlService.createUrlMapping(urlRequestDTO);
+
+        // Step 2: Retrieve it using getLongUrl (first call - should hit the database)
+        UrlResponseDTO firstCallResponse = urlService.getLongUrl(createdUrl.getShortUrl());
+        assertEquals("https://example.com", firstCallResponse.getLongUrl());
+
+        // Verify that repository was called exactly once for the first DB hit
+        verify(repository, times(1)).findByShortUrl(createdUrl.getShortUrl());
+
+        // Step 3: Make a second call to getLongUrl (should hit the cache)
+        UrlResponseDTO secondCallResponse = urlService.getLongUrl(createdUrl.getShortUrl());
+        assertEquals("https://example.com", secondCallResponse.getLongUrl());
+
+        // Verify that repository was not called again (cache should handle it)
+        verify(repository, times(1)).findByShortUrl(createdUrl.getShortUrl()); // Still 1 call, no additional hit
     }
 
 }

--- a/src/test/java/com/andrearozaki/urlshortener/unit/service/UrlServiceTest.java
+++ b/src/test/java/com/andrearozaki/urlshortener/unit/service/UrlServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.cache.CacheManager;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -32,11 +33,14 @@ class UrlServiceTest {
     @Mock
     private UrlEncoder urlEncoder;
 
+    @Mock
+    private CacheManager cacheManager;
+
     private UrlRequestDTO urlRequestDTO;
     private UrlEntity urlEntity;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         MockitoAnnotations.openMocks(this);
         urlRequestDTO = new UrlRequestDTO();
         urlRequestDTO.setLongUrl("https://www.example.com");
@@ -48,7 +52,7 @@ class UrlServiceTest {
     }
 
     @Test
-    void testCreateUrlMapping_Success() {
+    public void testCreateUrlMapping_Success() {
         when(urlEncoder.encodeUrl(anyString(), any(LocalDateTime.class))).thenReturn("encodedShortUrl");
         when(repository.save(any(UrlEntity.class))).thenReturn(urlEntity);
 
@@ -63,7 +67,7 @@ class UrlServiceTest {
     }
 
     @Test
-    void testCreateUrlMapping_Exception() {
+    public void testCreateUrlMapping_Exception() {
         when(repository.save(any(UrlEntity.class))).thenThrow(new RuntimeException("Database error"));
 
         UrlShortenerRuntimeException thrown = assertThrows(UrlShortenerRuntimeException.class, () -> {
@@ -74,7 +78,7 @@ class UrlServiceTest {
     }
 
     @Test
-    void testGetLongUrl_Success() {
+    public void testGetLongUrl_Success() {
         when(repository.findByShortUrl("encodedShortUrl")).thenReturn(Optional.of(urlEntity));
 
         UrlResponseDTO response = urlService.getLongUrl("encodedShortUrl");
@@ -87,7 +91,7 @@ class UrlServiceTest {
     }
 
     @Test
-    void testGetLongUrl_NotFound() {
+    public void testGetLongUrl_NotFound() {
         when(repository.findByShortUrl("nonExistingShortUrl")).thenReturn(Optional.empty());
 
         UrlNotFoundException thrown = assertThrows(UrlNotFoundException.class, () -> {


### PR DESCRIPTION
## Description
This pull request introduces Caffeine caching for the getLongUrl method in the UrlService class. The goal of this modification is to enhance performance and scalability by reducing the frequency of database access for frequently requested short URLs.

The modification was necessary to address potential performance bottlenecks in the URL shortening service. Each time a user requests the original long URL using a shortened URL, the service was querying the MongoDB database. For frequently accessed URLs, this approach could result in:

Increased response time for users.
Higher database load, leading to potential performance degradation as the application scales.
By integrating Caffeine caching, we aim to improve the application's overall efficiency by storing commonly requested URLs in memory, minimizing the need for repetitive database calls.

This pr adds:
- Integration with the Caffeine caching mechanism
- Creation of a cache called `urlcache` for the `shortUrl` field in the `getLongUrl` method of the UrlService
- An Intergration Test which verifies that the cache is being invoked and the requests dont hit the databases once the cache has a stored a value
